### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/test_calendario.py
+++ b/tests/test_calendario.py
@@ -1,0 +1,21 @@
+import unittest
+from datetime import datetime
+from brasileirao.core.entidades.time import Time
+from brasileirao.core.entidades.partida import Partida
+from brasileirao.core.entidades.calendario import Calendario
+
+class TestCalendario(unittest.TestCase):
+    def test_adicionar_partida_ajusta_data(self):
+        time_a = Time('Time A', 'A', 1900, 'Cidade A', 'Estadio A')
+        time_b = Time('Time B', 'B', 1900, 'Cidade B', 'Estadio B')
+        cal = Calendario()
+        primeira_data = datetime(2023, 1, 1)
+        segunda_data = datetime(2023, 1, 2)
+        p1 = Partida(time_a, time_b, 1, primeira_data)
+        p2 = Partida(time_a, time_b, 2, segunda_data)
+        cal.adicionar_partida(p1)
+        cal.adicionar_partida(p2)
+        self.assertGreaterEqual((p2.data - p1.data).days, 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_partida.py
+++ b/tests/test_partida.py
@@ -1,0 +1,21 @@
+import unittest
+from datetime import datetime
+from brasileirao.core.entidades.time import Time
+from brasileirao.core.entidades.partida import Partida
+
+class TestPartida(unittest.TestCase):
+    def test_finalizar_atualiza_pontos_e_saldo(self):
+        time_casa = Time('Casa', 'C', 1900, 'Cidade C', 'Estadio C')
+        time_vis = Time('Vis', 'V', 1900, 'Cidade V', 'Estadio V')
+        partida = Partida(time_casa, time_vis, 1, datetime(2023, 1, 1))
+        partida.placar_casa = 2
+        partida.placar_visitante = 1
+        partida.finalizar()
+        self.assertTrue(partida.concluida)
+        self.assertEqual(time_casa.pontos, 3)
+        self.assertEqual(time_vis.pontos, 0)
+        self.assertEqual(time_casa.saldo_gols, 1)
+        self.assertEqual(time_vis.saldo_gols, -1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test verifying `Calendario.adicionar_partida` adjusts dates
- add test checking `Partida.finalizar` updates points and goal difference

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_685e0ae3c6b88325abc6b9f072a5f340