### PR TITLE
Refatora GUI e adiciona validações

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,32 @@
+"""Ponto de entrada da aplicação GUI."""
+
 import tkinter as tk
+from importlib import metadata
+
 from brasileirao.gui import initializer
 
-class App:
-    def __init__(self):
-        self.root = tk.Tk()
-        initializer.start(self.root)
 
-    def run(self):
-        self.root.mainloop()
+def check_dependencies() -> None:
+    """Verifica a presença de dependências essenciais."""
+
+    required = {"PIL", "numpy", "pandas"}
+    installed = {dist.metadata["Name"] for dist in metadata.distributions()}
+    missing = required - installed
+    if missing:
+        raise ImportError(f"Faltam módulos: {', '.join(sorted(missing))}")
+
+class MainWindow(tk.Tk):
+    """Janela principal da aplicação."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        initializer.start(self)
+
+    def run(self) -> None:
+        """Inicia o loop principal da aplicação."""
+
+        self.mainloop()
 
 if __name__ == "__main__":
-    App().run()
+    check_dependencies()
+    MainWindow().run()

--- a/brasileirao/gui/frames/menu_frame.py
+++ b/brasileirao/gui/frames/menu_frame.py
@@ -1,13 +1,21 @@
+"""Frame inicial do aplicativo."""
+
 import tkinter as tk
+from datetime import datetime
+
 from .simulacao_frame import SimulacaoFrame
+from brasileirao.core.entidades.competicao import Competicao
 
 
 HEADER_FONT = ("Helvetica", 24, "bold")
 BUTTON_FONT = ("Helvetica", 14)
 
 class MenuFrame(tk.Frame):
-    def __init__(self, master):
+    """Menu principal exibido ao iniciar a aplicação."""
+
+    def __init__(self, master: tk.Misc):
         super().__init__(master)
+        self.competicao = Competicao("Brasileirão", datetime.now().year)
         self.criar_widgets()
 
     def criar_widgets(self):
@@ -31,12 +39,19 @@ class MenuFrame(tk.Frame):
             command=self.mostrar_login,
         ).pack(side="bottom", anchor="e", padx=10, pady=10)
 
-    def iniciar(self):
+    def iniciar(self) -> None:
         """Mostrar o frame de simulação e ocultar o menu."""
+
         self.pack_forget()
-        SimulacaoFrame(self.master).pack(fill="both", expand=True)
+        SimulacaoFrame(
+            parent=self.master,
+            competicao=self.competicao,
+            temporada=self.competicao.temporada,
+        ).pack(fill="both", expand=True)
 
     def mostrar_login(self):
+        """Exibe diálogo simples de login."""
+
         popup = tk.Toplevel(self)
         popup.title("Login")
         tk.Label(popup, text="Usuário:").pack()

--- a/brasileirao/gui/frames/simulacao_frame.py
+++ b/brasileirao/gui/frames/simulacao_frame.py
@@ -15,13 +15,19 @@ BUTTON_FONT = ("Helvetica", 14)
 
 
 class TabelaFrame(tk.Frame):
-    def __init__(self, master: tk.Misc, competicao: Competicao):
+    """Exibe a classificação de uma competição."""
+
+    def __init__(self, master: tk.Misc, competicao: Competicao | None = None):
         super().__init__(master)
+        if not competicao:
+            competicao = Competicao("Brasileirão", datetime.now().year)
         self.competicao = competicao
         self.lista = None
         self.criar_widgets()
 
     def criar_widgets(self):
+        """Cria widgets da tabela de classificação."""
+
         tk.Label(self, text="Classificação Série A", font=HEADER_FONT).pack(pady=5)
         frame = tk.Frame(self)
         frame.pack(fill="both", expand=True)
@@ -33,32 +39,33 @@ class TabelaFrame(tk.Frame):
         sb.config(command=self.lista.yview)
 
     def atualizar(self):
+        """Atualiza a tabela com a classificação atual."""
+
         self.lista.delete(0, tk.END)
         for i, time in enumerate(self.competicao.classificacao, 1):
             self.lista.insert(tk.END, f"{i:2d} - {time.nome} - {time.pontos} pts")
 
 
 class RodadaFrame(tk.Frame):
-    def __init__(self, master: tk.Misc, competicao: Competicao, rodada: int, concluir_cb):
+    """Exibe a lista de partidas de uma rodada."""
+
+    def __init__(
+        self,
+        master: tk.Misc,
+        competicao: Competicao,
+        rodada: int,
+        concluir_cb,
+    ) -> None:
         super().__init__(master)
         self.competicao = competicao
         self.rodada = rodada
         self.concluir_cb = concluir_cb
         self.lista = None
         self.btn_sim = None
-        self.criar_widgets()
-
-    def criar_widgets(self):
-        tk.Label(self, text=f"Rodada {self.rodada}", font=HEADER_FONT).pack(pady=5)
-    """Exibe a lista de partidas de uma rodada."""
-    def __init__(self, master, partidas=None, voltar_cb=None):
-        super().__init__(master)
-        self.voltar_cb = voltar_cb
-        self.partidas = partidas or []
         self._criar_widgets()
 
-    def _criar_widgets(self):
-        tk.Label(self, text="Jogos do Dia", font=HEADER_FONT).pack(pady=5)
+    def _criar_widgets(self) -> None:
+        tk.Label(self, text=f"Rodada {self.rodada}", font=HEADER_FONT).pack(pady=5)
         frame = tk.Frame(self)
         frame.pack(fill="both", expand=True)
         sb = tk.Scrollbar(frame)
@@ -68,16 +75,17 @@ class RodadaFrame(tk.Frame):
         self.lista.config(yscrollcommand=sb.set)
         sb.config(command=self.lista.yview)
         self.atualizar_lista()
+
         btns = tk.Frame(self)
         btns.pack(pady=5)
-        tk.Button(btns, text="Simular", font=BUTTON_FONT, width=18).pack(side="left", padx=5)
-        tk.Button(btns, text="Pular para Resultado", font=BUTTON_FONT, width=18).pack(side="left", padx=5)
-        tk.Button(btns, text="Avançar", font=BUTTON_FONT, width=18, command=self.voltar_cb).pack(side="left", padx=5)
         self.btn_sim = tk.Button(btns, text="Simular", font=BUTTON_FONT, width=18, command=self.simular)
         self.btn_sim.pack(side="left", padx=5)
+        tk.Button(btns, text="Pular para Resultado", font=BUTTON_FONT, width=18).pack(side="left", padx=5)
         tk.Button(btns, text="Avançar", font=BUTTON_FONT, width=18, command=self.finalizar).pack(side="left", padx=5)
 
     def atualizar_lista(self):
+        """Atualiza a lista de partidas na listbox."""
+
         self.lista.delete(0, tk.END)
         partidas = [p for p in self.competicao.partidas if p.rodada == self.rodada]
         for p in partidas:
@@ -88,6 +96,8 @@ class RodadaFrame(tk.Frame):
             self.lista.insert(tk.END, texto)
 
     def simular(self):
+        """Simula os jogos da rodada atual."""
+
         self.competicao.simular_rodada(self.rodada)
         self.btn_sim.config(state=tk.DISABLED)
         self.atualizar_lista()
@@ -95,87 +105,54 @@ class RodadaFrame(tk.Frame):
             self.master.tab_frame.atualizar()
 
     def finalizar(self):
+        """Encerra a rodada e aciona callback externa."""
+
         self.concluir_cb()
 
 
-class SimulacaoFrame(tk.Frame):
-    def __init__(self, master: tk.Misc):
-        super().__init__(master)
-        self.competicao = Competicao("Brasileirão", datetime.now().year)
-        for nome in TimesDB.TIMES_BRASILEIRO_A:
-            self.competicao.adicionar_time(Time(nome, nome, 1900, "Cidade", f"Estádio {nome}"))
-        self.competicao.gerar_calendario()
-        self.competicao.atualizar_classificacao()
-
-        self.rodada_atual = 1
-        self.tab_frame = TabelaFrame(self, self.competicao)
-        self.rodada_frame = None
-        self.btn_proxima = tk.Button(self, text="Próxima Rodada", font=BUTTON_FONT, width=18, command=self.mostrar_rodada)
-        self.mostrar_tabela()
-
-    def mostrar_tabela(self):
-        if self.rodada_frame:
-            self.rodada_frame.destroy()
-        self.tab_frame.atualizar()
-
-        self.atualizar_partidas(self.partidas)
-
-        btns = tk.Frame(self)
-        btns.pack(pady=5)
-        tk.Button(btns, text="Simular", font=BUTTON_FONT, width=18).pack(
-            side="left", padx=5
-        )
-        tk.Button(btns, text="Pular para Resultado", font=BUTTON_FONT, width=18).pack(
-            side="left", padx=5
-        )
-        if self.voltar_cb:
-            tk.Button(
-                btns,
-                text="Avançar",
-                font=BUTTON_FONT,
-                width=18,
-                command=self.voltar_cb,
-            ).pack(side="left", padx=5)
-
-    def atualizar_partidas(self, partidas):
-        """Atualiza a listbox com objetos de :class:`Partida`."""
-        self.partidas = partidas
-        self.lista.delete(0, tk.END)
-        for p in self.partidas:
-            try:
-                desc = (
-                    f"{p.time_casa.apelido} x {p.time_visitante.apelido}"
-                    f" - {p.placar_casa} x {p.placar_visitante}"
-                )
-            except AttributeError:
-                desc = str(p)
-            self.lista.insert("end", desc)
 
 class SimulacaoFrame(tk.Frame):
     """Frame principal da simulação."""
 
-    def __init__(self, master, partidas=None):
-        super().__init__(master)
-        self.times = self._criar_times()
-        self.tab_frame = TabelaFrame(self)
-        self.rodada_frame = RodadaFrame(self, self.mostrar_tabela)
-        self.btn_proxima = tk.Button(self, text="Próxima Rodada", font=BUTTON_FONT, width=18, command=self.mostrar_rodada)
-        self.btn_tecnicos = tk.Button(self, text="Ver Técnicos", font=BUTTON_FONT, width=18, command=self.mostrar_tecnicos)
+    def __init__(
+        self,
+        parent: tk.Misc,
+        competicao: Competicao | None = None,
+        temporada: int | None = None,
+        partidas=None,
+    ):
+        super().__init__(parent)
+
+        if competicao is None:
+            temporada = temporada or datetime.now().year
+            competicao = Competicao("Brasileirão", temporada)
+            for nome in TimesDB.TIMES_BRASILEIRO_A:
+                competicao.adicionar_time(
+                    Time(nome, nome, 1900, "Cidade", f"Estádio {nome}")
+                )
+            competicao.gerar_calendario()
+            competicao.atualizar_classificacao()
+
+        self.competicao = competicao
+        self.rodada_atual = 1
         self.partidas = partidas or []
-        self.tab_frame = TabelaFrame(self)
+
+        self.tab_frame = TabelaFrame(self, self.competicao)
         self.rodada_frame = RodadaFrame(
-            self, partidas=self.partidas, voltar_cb=self.mostrar_tabela
+            self, self.competicao, self.rodada_atual, self.finalizar_rodada
         )
         self.btn_proxima = tk.Button(
-            self,
-            text="Próxima Rodada",
-            font=BUTTON_FONT,
-            width=18,
-            command=self.mostrar_rodada,
+            self, text="Próxima Rodada", font=BUTTON_FONT, width=18, command=self.mostrar_rodada
         )
+        self.btn_tecnicos = tk.Button(
+            self, text="Ver Técnicos", font=BUTTON_FONT, width=18, command=self.mostrar_tecnicos
+        )
+
         self.mostrar_tabela()
 
     def _criar_times(self):
+        """Cria instâncias fictícias de times e técnicos."""
+
         times = []
         for nome in TimesDB.TIMES_BRASILEIRO_A:
             time = Time(nome, nome, 1900, "Cidade", "Estadio")
@@ -187,27 +164,37 @@ class SimulacaoFrame(tk.Frame):
         return times
 
     def mostrar_tecnicos(self):
+        """Exibe lista de técnicos em um popup."""
+
         TecnicosPopup(self, self.times)
 
     def mostrar_tabela(self):
         """Exibe a tabela de classificação."""
+
         self.rodada_frame.pack_forget()
         self.tab_frame.pack(fill="both", expand=True)
         self.btn_proxima.pack(pady=5)
         self.btn_tecnicos.pack(pady=5)
-        if self.rodada_atual <= len(self.competicao.partidas) // (len(self.competicao.times)//2):
+        if self.rodada_atual <= len(self.competicao.partidas) // (
+            len(self.competicao.times) // 2
+        ):
             self.btn_proxima.pack(pady=5)
 
     def mostrar_rodada(self):
         """Mostra as partidas da rodada atual sem recriar widgets."""
+
         self.tab_frame.pack_forget()
         self.btn_proxima.pack_forget()
         self.btn_tecnicos.pack_forget()
-        self.rodada_frame.pack(fill="both", expand=True)
-        self.rodada_frame = RodadaFrame(self, self.competicao, self.rodada_atual, self.finalizar_rodada)
+        self.rodada_frame.pack_forget()
+        self.rodada_frame = RodadaFrame(
+            self, self.competicao, self.rodada_atual, self.finalizar_rodada
+        )
         self.rodada_frame.pack(fill="both", expand=True)
 
     def finalizar_rodada(self):
+        """Avança para a próxima rodada."""
+
         self.rodada_atual += 1
         self.mostrar_tabela()
         self.rodada_frame.atualizar_partidas(self.partidas)

--- a/brasileirao/gui/initializer.py
+++ b/brasileirao/gui/initializer.py
@@ -1,27 +1,51 @@
+"""Inicialização da interface gráfica."""
+
+import logging
 import tkinter as tk
+
 from .frames.menu_frame import MenuFrame
 
-def _enforce_ratio(event: tk.Event):
-    root = event.widget
-    if getattr(root, "_ratio_lock", False):
+logger = logging.getLogger(__name__)
+
+def _enforce_ratio(event: tk.Event) -> None:
+    """Force 16:9 ratio for the top level window.
+
+    Args:
+        event: Evento de redimensionamento da janela.
+    """
+
+    root = event.widget.winfo_toplevel()
+    ratio_lock_supported = hasattr(root, "__dict__")
+    if ratio_lock_supported and getattr(root, "_ratio_lock", False):
         return
-    root._ratio_lock = True
+    if ratio_lock_supported:
+        root._ratio_lock = True
+
     desired = 16 / 9
     w, h = event.width, event.height
     if w / h > desired:
         w = int(h * desired)
     else:
         h = int(w / desired)
+
     if w < 1280:
         w = 1280
         h = int(w / desired)
     if h < 720:
         h = 720
         w = int(h * desired)
-    root.geometry(f"{w}x{h}")
-    root._ratio_lock = False
 
-def start(root: tk.Tk):
+    if hasattr(root, "geometry"):
+        root.geometry(f"{w}x{h}")
+    else:
+        logger.warning("Widget %s não suporta geometry", type(event.widget))
+
+    if ratio_lock_supported:
+        root._ratio_lock = False
+
+def start(root: tk.Tk) -> None:
+    """Configura a janela principal e exibe o menu."""
+
     root.title("Liga Brasileira")
     root.geometry("1280x720")
     root.minsize(1280, 720)

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -1,0 +1,19 @@
+import types
+from brasileirao.gui.initializer import _enforce_ratio
+
+class FakeWidget:
+    def winfo_toplevel(self):
+        return object()
+
+class FakeEvent:
+    def __init__(self, width=100, height=100):
+        self.width = width
+        self.height = height
+        self.widget = FakeWidget()
+
+# Ensure function does not raise when geometry is unsupported
+
+def test_enforce_ratio_no_geometry(caplog):
+    event = FakeEvent()
+    _enforce_ratio(event)
+    assert any('não suporta geometry' in msg for msg in caplog.text.splitlines())


### PR DESCRIPTION
## Summary
- improve aspect ratio handling for non-window widgets
- pass competition context when opening simulation from menu
- clean up SimulacaoFrame and RodadaFrame classes
- create MainWindow class and dependency checker
- add regression test for `_enforce_ratio`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0ea5c0d88325b00109ad83fd33d9