### PR TITLE
Implement central controller and improve geometry checks

### DIFF
--- a/brasileirao/gui/controller.py
+++ b/brasileirao/gui/controller.py
@@ -1,0 +1,18 @@
+import datetime
+from brasileirao.core.entidades.competicao import Competicao
+from brasileirao.core.entidades.time import Time
+from brasileirao.data.times_db import TimesDB
+
+
+class AppController:
+    """Gerencia os dados principais da aplicação."""
+
+    def __init__(self) -> None:
+        temporada = datetime.datetime.now().year
+        self.campeonato = Competicao("Brasileirão", temporada)
+        for nome in TimesDB.TIMES_BRASILEIRO_A:
+            self.campeonato.adicionar_time(
+                Time(nome, nome, 1900, "Cidade", f"Estádio {nome}")
+            )
+        self.campeonato.gerar_calendario()
+        self.campeonato.atualizar_classificacao()

--- a/brasileirao/gui/frames/menu_frame.py
+++ b/brasileirao/gui/frames/menu_frame.py
@@ -1,10 +1,8 @@
 """Frame inicial do aplicativo."""
 
 import tkinter as tk
-from datetime import datetime
-
 from .simulacao_frame import SimulacaoFrame
-from brasileirao.core.entidades.competicao import Competicao
+from ..controller import AppController
 
 
 HEADER_FONT = ("Helvetica", 24, "bold")
@@ -13,9 +11,10 @@ BUTTON_FONT = ("Helvetica", 14)
 class MenuFrame(tk.Frame):
     """Menu principal exibido ao iniciar a aplicação."""
 
-    def __init__(self, master: tk.Misc):
+    def __init__(self, master: tk.Misc, controller: AppController):
         super().__init__(master)
-        self.competicao = Competicao("Brasileirão", datetime.now().year)
+        self.controller = controller
+        self.competicao = controller.campeonato
         self.criar_widgets()
 
     def criar_widgets(self):
@@ -45,8 +44,7 @@ class MenuFrame(tk.Frame):
         self.pack_forget()
         SimulacaoFrame(
             parent=self.master,
-            competicao=self.competicao,
-            temporada=self.competicao.temporada,
+            controller=self.controller,
         ).pack(fill="both", expand=True)
 
     def mostrar_login(self):

--- a/brasileirao/gui/frames/simulacao_frame.py
+++ b/brasileirao/gui/frames/simulacao_frame.py
@@ -1,13 +1,9 @@
 import tkinter as tk
-from ..widgets import TecnicosPopup
-from brasileirao.data.times_db import TimesDB
-from brasileirao.core.entidades.time import Time
-from brasileirao.core.entidades.tecnico import Tecnico
-from brasileirao.core.enums.estilo_tatico import EstiloTatico
 from datetime import datetime
+
+from ..widgets import TecnicosPopup
 from brasileirao.core.entidades.competicao import Competicao
-from brasileirao.core.entidades.time import Time
-from brasileirao.data.times_db import TimesDB
+from ..controller import AppController
 
 HEADER_FONT = ("Helvetica", 18, "bold")
 LIST_FONT = ("Helvetica", 12)
@@ -114,26 +110,13 @@ class RodadaFrame(tk.Frame):
 class SimulacaoFrame(tk.Frame):
     """Frame principal da simulação."""
 
-    def __init__(
-        self,
-        parent: tk.Misc,
-        competicao: Competicao | None = None,
-        temporada: int | None = None,
-        partidas=None,
-    ):
+    def __init__(self, parent: tk.Misc, controller: AppController):
         super().__init__(parent)
 
-        if competicao is None:
-            temporada = temporada or datetime.now().year
-            competicao = Competicao("Brasileirão", temporada)
-            for nome in TimesDB.TIMES_BRASILEIRO_A:
-                competicao.adicionar_time(
-                    Time(nome, nome, 1900, "Cidade", f"Estádio {nome}")
-                )
-            competicao.gerar_calendario()
-            competicao.atualizar_classificacao()
+        self.controller = controller
+        self.competicao = controller.campeonato
+        partidas = None
 
-        self.competicao = competicao
         self.rodada_atual = 1
         self.partidas = partidas or []
 
@@ -150,23 +133,10 @@ class SimulacaoFrame(tk.Frame):
 
         self.mostrar_tabela()
 
-    def _criar_times(self):
-        """Cria instâncias fictícias de times e técnicos."""
-
-        times = []
-        for nome in TimesDB.TIMES_BRASILEIRO_A:
-            time = Time(nome, nome, 1900, "Cidade", "Estadio")
-            tecnico = Tecnico(f"Técnico {nome}", 50, "Brasil")
-            tecnico.estilo_tatico = EstiloTatico.BALANCEADO
-            tecnico.time = time
-            time.tecnico = tecnico
-            times.append(time)
-        return times
-
     def mostrar_tecnicos(self):
         """Exibe lista de técnicos em um popup."""
 
-        TecnicosPopup(self, self.times)
+        TecnicosPopup(self, self.competicao.times)
 
     def mostrar_tabela(self):
         """Exibe a tabela de classificação."""

--- a/brasileirao/gui/initializer.py
+++ b/brasileirao/gui/initializer.py
@@ -4,6 +4,7 @@ import logging
 import tkinter as tk
 
 from .frames.menu_frame import MenuFrame
+from .controller import AppController
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,13 @@ def _enforce_ratio(event: tk.Event) -> None:
         event: Evento de redimensionamento da janela.
     """
 
-    root = event.widget.winfo_toplevel()
+    widget = event.widget
+    if isinstance(widget, (tk.Tk, tk.Toplevel)):
+        root = widget
+    else:
+        logger.warning("Widget %s não suporta geometry", type(widget))
+        return
+
     ratio_lock_supported = hasattr(root, "__dict__")
     if ratio_lock_supported and getattr(root, "_ratio_lock", False):
         return
@@ -35,10 +42,7 @@ def _enforce_ratio(event: tk.Event) -> None:
         h = 720
         w = int(h * desired)
 
-    if hasattr(root, "geometry"):
-        root.geometry(f"{w}x{h}")
-    else:
-        logger.warning("Widget %s não suporta geometry", type(event.widget))
+    root.geometry(f"{w}x{h}")
 
     if ratio_lock_supported:
         root._ratio_lock = False
@@ -50,4 +54,5 @@ def start(root: tk.Tk) -> None:
     root.geometry("1280x720")
     root.minsize(1280, 720)
     root.bind("<Configure>", _enforce_ratio)
-    MenuFrame(root).pack(fill="both", expand=True)
+    controller = AppController()
+    MenuFrame(root, controller).pack(fill="both", expand=True)


### PR DESCRIPTION
## Summary
- add new `AppController` to manage the competition
- only apply `geometry()` on root windows and warn otherwise
- initialize `MenuFrame` and `SimulacaoFrame` with the controller

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e10e142e48325b5c5cbf3e46f6995