### PR TITLE
Fix copa calendar and match simulation

### DIFF
--- a/core/entities/copa.py
+++ b/core/entities/copa.py
@@ -1,5 +1,6 @@
 """Entidade Copa."""
 
+from datetime import timedelta
 from .competicao import Competicao
 from .partida import Partida
 
@@ -17,7 +18,12 @@ class Copa(Competicao):
             for i in range(0, len(times), 2):
                 casa = times[i]
                 visitante = times[i + 1]
-                partida = Partida(casa, visitante, rodada, self.calendario.proxima_data_disponivel(self.calendario.partidas[-1].data if self.calendario.partidas else self.calendario.data_inicio))
+                data_base = (
+                    self.calendario.partidas[-1].data + timedelta(days=3)
+                    if self.calendario.partidas
+                    else self.calendario.data_inicio
+                )
+                partida = Partida(casa, visitante, rodada, data_base)
                 self.calendario.adicionar_partida(partida)
                 self.partidas.append(partida)
                 nova_rodada.append(partida)

--- a/core/entities/partida.py
+++ b/core/entities/partida.py
@@ -22,3 +22,4 @@ class Partida:
         """Simula a partida utilizando o simulador."""
         from .simulador_partida import SimuladorPartida
         SimuladorPartida(self).simular()
+        self.concluida = True

--- a/core/entities/simulador_partida.py
+++ b/core/entities/simulador_partida.py
@@ -16,29 +16,59 @@ class SimuladorPartida:
         self.modifier_visitante = 1.0
 
     def simular(self) -> None:
-        """Executa três subfases: meio-campo, ataque e defesa."""
-        for _ in range(90 // 30):
-            self.phase += 1
+        """Executa fases limitadas em meio-campo, ataque e gol."""
+        while self.phase < 20:
             self._meio_campo()
+            if self.phase >= 20:
+                break
             self._ataque()
-            self._defesa()
+            if self.phase >= 20:
+                break
+            self._gol()
         self.partida.concluida = True
 
-    def _meio_campo(self):
+    def _meio_campo(self) -> None:
         self.subphase = 1
+        self.phase += 1
         self.partida.fases.append(FasePartida.MEIO_CAMPO)
+        roll_casa = random.random() * self.modifier_casa
+        roll_visitante = random.random() * self.modifier_visitante
+        if roll_casa >= roll_visitante:
+            self.possession = self.partida.time_casa
+        else:
+            self.possession = self.partida.time_visitante
 
-    def _ataque(self):
+    def _ataque(self) -> None:
         self.subphase = 2
+        self.phase += 1
         self.partida.fases.append(FasePartida.ATAQUE)
-        if random.random() < 0.1:
+        ataque = random.random() * (
+            self.modifier_casa if self.possession == self.partida.time_casa else self.modifier_visitante
+        )
+        defesa = random.random()
+        if ataque < defesa:
+            self.possession = (
+                self.partida.time_visitante
+                if self.possession == self.partida.time_casa
+                else self.partida.time_casa
+            )
+
+    def _gol(self) -> None:
+        self.subphase = 3
+        self.phase += 1
+        self.partida.fases.append(FasePartida.GOL)
+        chute = random.random() * (
+            self.modifier_casa if self.possession == self.partida.time_casa else self.modifier_visitante
+        )
+        defesa = random.random()
+        if chute > defesa:
             if self.possession == self.partida.time_casa:
                 self.partida.placar_casa += 1
             else:
                 self.partida.placar_visitante += 1
-            self.partida.fases.append(FasePartida.GOL)
-
-    def _defesa(self):
-        self.subphase = 3
-        self.partida.fases.append(FasePartida.DEFESA)
-        self.possession = self.partida.time_visitante if self.possession == self.partida.time_casa else self.partida.time_casa
+        else:
+            self.possession = (
+                self.partida.time_visitante
+                if self.possession == self.partida.time_casa
+                else self.partida.time_casa
+            )

--- a/tests/test_competicao.py
+++ b/tests/test_competicao.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from core.entities.competicao import Competicao
+from core.entities.time import Time
+from core.entities.partida import Partida
+
+
+def test_simular_rodada():
+    comp = Competicao('Teste', 2023)
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    comp.times = [t1, t2]
+    partida = Partida(t1, t2, 1, datetime.now())
+    comp.partidas = [partida]
+    comp.simular_rodada(1)
+    assert partida.concluida

--- a/tests/test_copa.py
+++ b/tests/test_copa.py
@@ -1,0 +1,15 @@
+from datetime import date
+from core.entities.copa import Copa
+from core.entities.time import Time
+
+
+def test_copa_gera_chave_datas():
+    copa = Copa('Copa', 2023)
+    times = [Time(str(i), str(i), 1900, 'X', 'Y') for i in range(4)]
+    copa.times = times
+    copa.calendario.data_inicio = date(2023, 1, 1)
+    copa.gerar_calendario()
+    assert len(copa.partidas) == 3
+    datas = [p.data for p in copa.calendario.partidas]
+    for d1, d2 in zip(datas, datas[1:]):
+        assert (d2 - d1).days >= 3

--- a/tests/test_simulador_partida.py
+++ b/tests/test_simulador_partida.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from core.entities.time import Time
+from core.entities.partida import Partida
+from core.entities.simulador_partida import SimuladorPartida
+
+
+def test_simulador_limites_e_concluida():
+    p = Partida(Time('A', 'A', 1900, 'X', 'Y'), Time('B', 'B', 1900, 'X', 'Y'), 1, datetime.now())
+    simulador = SimuladorPartida(p)
+    simulador.simular()
+    assert 0 <= simulador.phase <= 20
+    assert p.concluida


### PR DESCRIPTION
## Summary
- fix syntax in `Copa.gerar_calendario` and ensure 3-day spacing
- mark `Partida` as concluded after simulation
- implement richer `SimuladorPartida` phases with limits
- add tests for copa, competicao and simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e42741fe883258c101d7ef1f641ee