### PR TITLE
Remove tkinter from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Simulador simples de competições do futebol brasileiro.
 pip install -r requirements.txt
 ```
 
+Certifique-se de que a biblioteca padrão **Tkinter** do Python esteja
+disponível no seu ambiente, pois ela é necessária para a interface gráfica.
+
 ## Uso
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 name = "LigaBrasileira"
 version = "0.1.0"
 authors = ["Seu Nome <email>"]
-dependencies = ["tkinter", "pytest", "flake8"]
+dependencies = ["pytest", "flake8"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-tkinter
 pytest
 flake8


### PR DESCRIPTION
## Summary
- drop tkinter from requirements and pyproject
- note that Python's built‑in Tkinter library is required

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e48c4ba2c8325aaf313777e9749f2