### PR TITLE
Expand temporada historico data

### DIFF
--- a/persistence/history.py
+++ b/persistence/history.py
@@ -5,9 +5,10 @@ class TemporadaHistorico:
 
     def __init__(self, ano: int) -> None:
         self.ano = ano
-        self.resultados = []
-        self.trofeus = {}
-        self.artilheiros = []
+        self.campeonatos: dict[str, str] = {}
+        self.artilheiros: dict[str, str] = {}
+        self.classificacao: list[str] = []
+        self.trofeus_por_time: dict[str, list[str]] = {}
 
 class Historico:
     """Coleção de temporadas."""
@@ -17,3 +18,24 @@ class Historico:
 
     def adicionar_temporada(self, temporada: TemporadaHistorico) -> None:
         self.temporadas.append(temporada)
+
+    def _obter_ou_criar(self, ano: int) -> TemporadaHistorico:
+        for temp in self.temporadas:
+            if temp.ano == ano:
+                return temp
+        novo = TemporadaHistorico(ano)
+        self.temporadas.append(novo)
+        return novo
+
+    def registrar_campeonato(self, ano: int, nome: str, campeao: str) -> None:
+        temporada = self._obter_ou_criar(ano)
+        temporada.campeonatos[nome] = campeao
+        temporada.trofeus_por_time.setdefault(campeao, []).append(nome)
+
+    def registrar_artilheiro(self, ano: int, competicao: str, jogador: str) -> None:
+        temporada = self._obter_ou_criar(ano)
+        temporada.artilheiros[competicao] = jogador
+
+    def registrar_classificacao(self, ano: int, classificacao: list[str]) -> None:
+        temporada = self._obter_ou_criar(ano)
+        temporada.classificacao = classificacao

--- a/tests/test_historico.py
+++ b/tests/test_historico.py
@@ -1,0 +1,18 @@
+from persistence.history import Historico
+
+
+def test_registrar_campeonato():
+    hist = Historico()
+    hist.registrar_campeonato(2023, "Liga", "Time A")
+    temporada = hist.temporadas[0]
+    assert temporada.campeonatos["Liga"] == "Time A"
+    assert "Liga" in temporada.trofeus_por_time["Time A"]
+
+
+def test_registrar_artilheiro_e_classificacao():
+    hist = Historico()
+    hist.registrar_artilheiro(2024, "Liga", "Jogador X")
+    hist.registrar_classificacao(2024, ["Time A", "Time B"])
+    temporada = hist.temporadas[0]
+    assert temporada.artilheiros["Liga"] == "Jogador X"
+    assert temporada.classificacao == ["Time A", "Time B"]


### PR DESCRIPTION
## Summary
- extend TemporadaHistorico with champs, scorers, standings and trophies
- provide helper methods in Historico for registering the new data
- test new history features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e48c221a48325ba135e17d55c9cb2