### PR TITLE
Add season simulator

### DIFF
--- a/simulation/interface.py
+++ b/simulation/interface.py
@@ -1,0 +1,6 @@
+"""Interfaces para conexão com sistemas de interface gráfica."""
+
+class InterfaceTemporada:
+    """Placeholder para integração futura com GUI."""
+
+    pass

--- a/simulation/temporada.py
+++ b/simulation/temporada.py
@@ -1,0 +1,74 @@
+"""Simulação básica de uma temporada."""
+
+from __future__ import annotations
+
+from typing import List
+
+from core.entities.competicao import Competicao
+from core.entities.time import Time
+from core.entities.jogador import Jogador
+from core.enums.posicao import Posicao
+from core.entities.liga import Liga
+from core.systems.sistema_classificacao import atualizar_factors_times
+from core.systems.sistema_eventos import (
+    verificar_demissao_tecnicos,
+    verificar_lesoes,
+)
+from core.systems.sistema_financeiro import pagar_salarios_semanais
+from core.systems.sistema_regens import regenerar_jogadores
+
+
+class SimuladorTemporada:
+    """Executa rodadas e gerencia eventos sazonais."""
+
+    def __init__(self, competicoes: List[Competicao]) -> None:
+        self.competicoes = competicoes
+        self.rodada_atual = 1
+        self.times: List[Time] = []
+        for comp in competicoes:
+            for t in comp.times:
+                if t not in self.times:
+                    self.times.append(t)
+
+    def executar_rodada(self) -> None:
+        """Simula a rodada atual em todas as competições."""
+        for comp in self.competicoes:
+            comp.simular_rodada(self.rodada_atual)
+            if isinstance(comp, Liga):
+                atualizar_factors_times(comp)
+
+        jogadores = [j for t in self.times for j in t.jogadores]
+        verificar_lesoes(jogadores)
+        verificar_demissao_tecnicos(self.times)
+        pagar_salarios_semanais(self.times)
+        regenerar_jogadores(jogadores)
+        self._mercado_transferencias()
+
+        self.rodada_atual += 1
+
+    def _mercado_transferencias(self) -> None:
+        """Realiza transferências simples entre times."""
+        for comprador in self.times:
+            if comprador.orcamento <= 0:
+                continue
+            vendedores = [t for t in self.times if t is not comprador and t.jogadores]
+            if not vendedores:
+                continue
+            vendedor = vendedores[0]
+            jogador = vendedor.jogadores[0]
+            valor = jogador.valor_mercado()
+            if comprador.orcamento >= valor:
+                vendedor.jogadores.remove(jogador)
+                comprador.jogadores.append(jogador)
+                comprador.orcamento -= valor
+                vendedor.orcamento += valor
+                jogador.time = comprador
+                break
+            else:
+                if comprador.orcamento > 1_000_000:
+                    novo = Jogador("Reforço", 20, "Brasil", Posicao.ATACANTE)
+                    novo.time = comprador
+                    comprador.jogadores.append(novo)
+                    comprador.orcamento -= 1_000_000
+                break
+

--- a/tests/test_simulador_temporada.py
+++ b/tests/test_simulador_temporada.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+import random
+
+from simulation.temporada import SimuladorTemporada
+from core.entities.competicao import Competicao
+from core.entities.time import Time
+from core.entities.partida import Partida
+from core.entities.jogador import Jogador
+from core.enums.posicao import Posicao
+
+
+def test_executar_rodada_e_transferencia():
+    random.seed(0)
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+
+    j1 = Jogador('J1', 20, 'BR', Posicao.ATACANTE)
+    j1.qualidade_geral = 10
+    j1.potencial = 10
+    j1.time = t1
+    t1.jogadores.append(j1)
+
+    j2 = Jogador('J2', 21, 'BR', Posicao.MEIA)
+    j2.qualidade_geral = 10
+    j2.potencial = 10
+    j2.time = t2
+    t2.jogadores.append(j2)
+
+    t1.orcamento = j2.valor_mercado() + 1_000_000
+    t2.orcamento = 0
+
+    comp = Competicao('Teste', 2023)
+    comp.times = [t1, t2]
+    partida = Partida(t1, t2, 1, datetime.now())
+    comp.partidas = [partida]
+
+    sim = SimuladorTemporada([comp])
+    sim.executar_rodada()
+
+    assert partida.concluida
+    assert len(t1.jogadores) == 2
+    assert len(t2.jogadores) == 0
+    assert sim.rodada_atual == 2


### PR DESCRIPTION
## Summary
- implement `SimuladorTemporada` to handle rounds and a simple transfer market
- stub out `InterfaceTemporada` for future GUI features
- test season simulator round execution and transfers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e48c1190883258fe733fb23f698a8