### PR TITLE
Add default start date for Calendario

### DIFF
--- a/core/entities/calendario.py
+++ b/core/entities/calendario.py
@@ -9,6 +9,7 @@ class Calendario:
     def __init__(self) -> None:
         self.partidas: list[Partida] = []
         self.rodada_atual = 1
+        self.data_inicio: date = date.today()
 
     def adicionar_partida(self, partida: Partida) -> None:
         """Adiciona partida mantendo espaçamento mínimo."""

--- a/tests/test_copa.py
+++ b/tests/test_copa.py
@@ -1,4 +1,3 @@
-from datetime import date
 from core.entities.copa import Copa
 from core.entities.time import Time
 
@@ -7,9 +6,10 @@ def test_copa_gera_chave_datas():
     copa = Copa('Copa', 2023)
     times = [Time(str(i), str(i), 1900, 'X', 'Y') for i in range(4)]
     copa.times = times
-    copa.calendario.data_inicio = date(2023, 1, 1)
+    data_inicio = copa.calendario.data_inicio
     copa.gerar_calendario()
     assert len(copa.partidas) == 3
     datas = [p.data for p in copa.calendario.partidas]
+    assert datas[0] == data_inicio
     for d1, d2 in zip(datas, datas[1:]):
         assert (d2 - d1).days >= 3


### PR DESCRIPTION
## Summary
- default Calendario start date to `date.today()`
- adjust Copa calendar test to rely on default start date

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685edd96650c8325b621a4257eb71929