### PR TITLE
Implement league results and sorting

### DIFF
--- a/core/entities/liga.py
+++ b/core/entities/liga.py
@@ -1,6 +1,7 @@
 """Entidade Liga."""
 
 from .competicao import Competicao
+from .partida import Partida
 
 class Liga(Competicao):
     """Liga em formato de pontos corridos."""
@@ -8,3 +9,26 @@ class Liga(Competicao):
     def gerar_calendario(self) -> None:
         super().gerar_calendario()
         self.classificacao = self.times[:]
+
+    def _aplicar_resultado(self, partida: Partida) -> None:
+        """Atualiza pontuação e saldo de gols dos times."""
+        casa = partida.time_casa
+        visitante = partida.time_visitante
+        casa.saldo_gols += partida.placar_casa - partida.placar_visitante
+        visitante.saldo_gols += partida.placar_visitante - partida.placar_casa
+
+        if partida.placar_casa > partida.placar_visitante:
+            casa.pontos += 3
+        elif partida.placar_casa < partida.placar_visitante:
+            visitante.pontos += 3
+        else:
+            casa.pontos += 1
+            visitante.pontos += 1
+
+    def simular_rodada(self, rodada: int) -> None:
+        """Simula as partidas de uma rodada e atualiza a classificação."""
+        for partida in self.partidas:
+            if partida.rodada == rodada and not partida.concluida:
+                partida.simular()
+                self._aplicar_resultado(partida)
+        self.classificacao.sort(key=lambda t: (t.pontos, t.saldo_gols), reverse=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,3 @@ name = "LigaBrasileira"
 version = "0.1.0"
 authors = ["Seu Nome <email>"]
 dependencies = ["tkinter", "pytest", "pytest-cov", "flake8"]
-dependencies = ["pytest", "flake8"]

--- a/tests/test_liga_points.py
+++ b/tests/test_liga_points.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from core.entities.liga import Liga
+from core.entities.time import Time
+from core.entities.partida import Partida
+
+
+def test_pontos_e_classificacao():
+    liga = Liga('L', 2023)
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    liga.times = [t1, t2]
+
+    # cria duas partidas manualmente
+    p1 = Partida(t1, t2, 1, datetime.now())
+    p2 = Partida(t2, t1, 2, datetime.now())
+    liga.partidas = [p1, p2]
+    liga.classificacao = [t2, t1]  # ordem invertida para testar ordenacao
+
+    def sim1():
+        p1.placar_casa = 2
+        p1.placar_visitante = 0
+        p1.concluida = True
+    p1.simular = sim1
+
+    liga.simular_rodada(1)
+    assert t1.pontos == 3
+    assert t2.pontos == 0
+    assert t1.saldo_gols == 2
+    assert t2.saldo_gols == -2
+    assert liga.classificacao[0] == t1
+
+    def sim2():
+        p2.placar_casa = 1
+        p2.placar_visitante = 0
+        p2.concluida = True
+    p2.simular = sim2
+
+    liga.simular_rodada(2)
+    assert t2.pontos == 3
+    assert liga.classificacao[0] == t1


### PR DESCRIPTION
## Summary
- implement `_aplicar_resultado` helper in `Liga`
- update `simular_rodada` to apply match results and sort standings
- fix duplicated entry in `pyproject.toml`
- add unit test ensuring points/saldo_gols update and classification ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edd988cd883259e4a10a57a072fd5