### PR TITLE
Add basic manager mode start

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,10 @@
 
 import tkinter as tk
 from gui.frames.main_menu_frame import MainMenuFrame
+from gui.frames.manager_frame import ManagerFrame
+from core.entities.time import Time
+from simulation.competition.liga_brasileira import LigaBrasileira
+from simulation.manager.modo_manager import ModoPlayer
 
 class App(tk.Tk):
     """Janela principal."""
@@ -9,10 +13,34 @@ class App(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title("Liga Brasileira")
-        MainMenuFrame(self, self).pack(fill="both", expand=True)
+
+        # Liga de testes com alguns times fictícios
+        self.liga = LigaBrasileira("Liga Teste", 2023)
+        self.liga.times = [
+            Time("Time A", "A", 1900, "Cidade A", "Estádio A"),
+            Time("Time B", "B", 1900, "Cidade B", "Estádio B"),
+            Time("Time C", "C", 1900, "Cidade C", "Estádio C"),
+        ]
+        for t in self.liga.times:
+            t.liga = self.liga
+        self.liga.gerar_calendario()
+
+        # Frame atual da aplicação
+        self.frame = MainMenuFrame(self, self)
+        self.frame.pack(fill="both", expand=True)
 
     def iniciar_manager(self) -> None:
-        pass  # placeholder para inicializar modo manager
+        """Entra no modo manager."""
+        # Destrói o frame atual (menu principal)
+        self.frame.destroy()
+
+        # Jogador controlará o primeiro time da liga
+        time_escolhido = self.liga.times[0]
+        self.manager = ModoPlayer(time_escolhido)
+
+        # Exibe a tela de gerenciamento
+        self.frame = ManagerFrame(self, self.manager)
+        self.frame.pack(fill="both", expand=True)
 
 if __name__ == "__main__":
     App().mainloop()


### PR DESCRIPTION
## Summary
- hook up a simple test league in `app.py`
- choose a team for the player and start `ModoPlayer`
- update `iniciar_manager` to show `ManagerFrame`

## Testing
- `pytest -q -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_685edd9bb9c883259a7a93cd9fda1217