### PR TITLE
Assign league reference to teams

### DIFF
--- a/core/entities/calendario.py
+++ b/core/entities/calendario.py
@@ -20,6 +20,6 @@ class Calendario:
         """Retorna a próxima data livre a partir de ``data_inicio``."""
         data = data_inicio
         if self.partidas:
-            while any(abs((p.data - data).days) < 3 for p in self.partidas):
+            while any(abs(((p.data.date() if hasattr(p.data, 'date') else p.data) - data).days) < 3 for p in self.partidas):
                 data += timedelta(days=1)
         return data

--- a/core/entities/liga.py
+++ b/core/entities/liga.py
@@ -6,5 +6,7 @@ class Liga(Competicao):
     """Liga em formato de pontos corridos."""
 
     def gerar_calendario(self) -> None:
+        for time in self.times:
+            time.liga = self
         super().gerar_calendario()
         self.classificacao = self.times[:]

--- a/core/entities/time.py
+++ b/core/entities/time.py
@@ -12,6 +12,7 @@ class Time:
         self.fundacao = fundacao
         self.cidade = cidade
         self.estadio = estadio
+        self.liga = None
         self.jogadores: List['Jogador'] = []
         self.tecnico = None
         self.factor_torcida = 10

--- a/gui/frames/manager_frame.py
+++ b/gui/frames/manager_frame.py
@@ -9,4 +9,6 @@ class ManagerFrame(tk.Frame):
     def __init__(self, master: tk.Misc, manager) -> None:
         super().__init__(master)
         self.manager = manager
-        ClassificacaoWidget(self, manager.time.liga.classificacao).pack()
+        liga = getattr(manager.time, "liga", None)
+        classificacao = liga.classificacao if liga else []
+        ClassificacaoWidget(self, classificacao).pack()

--- a/simulation/competition/liga_brasileira.py
+++ b/simulation/competition/liga_brasileira.py
@@ -8,6 +8,8 @@ class LigaBrasileira(Liga):
     """Liga nacional com calendário semanal."""
 
     def gerar_calendario(self) -> None:
+        for time in self.times:
+            time.liga = self
         self.calendario = Calendario()
         data = date(self.temporada, 1, 1)
         self.partidas.clear()
@@ -20,6 +22,7 @@ class LigaBrasileira(Liga):
                 partida_volta = self._criar_partida(visitante, casa, rodada, data)
                 rodada += 1
                 data = self.calendario.proxima_data_disponivel(data)
+        self.classificacao = self.times[:]
 
     def _criar_partida(self, casa, visitante, rodada, data):
         from ...core.entities.partida import Partida

--- a/tests/test_time_liga.py
+++ b/tests/test_time_liga.py
@@ -1,0 +1,12 @@
+from core.entities.liga import Liga
+from core.entities.time import Time
+
+
+def test_liga_atribuida_aos_times():
+    liga = Liga('Serie A', 2023)
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    liga.times = [t1, t2]
+    liga.gerar_calendario()
+    assert t1.liga is liga
+    assert t2.liga is liga


### PR DESCRIPTION
## Summary
- attach a `liga` attribute to `Time`
- propagate `liga` when generating Liga calendars
- make ManagerFrame resilient if no league exists
- fix date handling in `Calendario.proxima_data_disponivel`
- add tests for new `liga` assignment

## Testing
- `pytest -q -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_685edd9d40d0832585399855de361896