### PR TITLE
Update Partida to apply match results automatically

### DIFF
--- a/core/entities/liga.py
+++ b/core/entities/liga.py
@@ -13,19 +13,8 @@ class Liga(Competicao):
         self.classificacao = self.times[:]
 
     def _aplicar_resultado(self, partida: Partida) -> None:
-        """Atualiza pontuação e saldo de gols dos times."""
-        casa = partida.time_casa
-        visitante = partida.time_visitante
-        casa.saldo_gols += partida.placar_casa - partida.placar_visitante
-        visitante.saldo_gols += partida.placar_visitante - partida.placar_casa
-
-        if partida.placar_casa > partida.placar_visitante:
-            casa.pontos += 3
-        elif partida.placar_casa < partida.placar_visitante:
-            visitante.pontos += 3
-        else:
-            casa.pontos += 1
-            visitante.pontos += 1
+        """Atualiza pontuação e saldo de gols usando a partida."""
+        partida.aplicar_resultado()
 
     def simular_rodada(self, rodada: int) -> None:
         """Simula as partidas de uma rodada e atualiza a classificação."""

--- a/core/entities/partida.py
+++ b/core/entities/partida.py
@@ -17,9 +17,28 @@ class Partida:
         self.fases: list = []
         self.arbitro = None
         self.concluida = False
+        self.resultado_aplicado = False
 
     def simular(self) -> None:
         """Simula a partida utilizando o simulador."""
         from .simulador_partida import SimuladorPartida
         SimuladorPartida(self).simular()
         self.concluida = True
+        self.aplicar_resultado()
+
+    def aplicar_resultado(self) -> None:
+        """Atualiza pontos e saldo de gols dos times se ainda não feito."""
+        if self.resultado_aplicado:
+            return
+        casa = self.time_casa
+        visitante = self.time_visitante
+        casa.saldo_gols += self.placar_casa - self.placar_visitante
+        visitante.saldo_gols += self.placar_visitante - self.placar_casa
+        if self.placar_casa > self.placar_visitante:
+            casa.pontos += 3
+        elif self.placar_casa < self.placar_visitante:
+            visitante.pontos += 3
+        else:
+            casa.pontos += 1
+            visitante.pontos += 1
+        self.resultado_aplicado = True

--- a/tests/test_partida_resultado.py
+++ b/tests/test_partida_resultado.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from core.entities.time import Time
+from core.entities.partida import Partida
+from core.entities.simulador_partida import SimuladorPartida
+
+
+def test_partida_simular_atualiza_pontos(monkeypatch):
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    partida = Partida(t1, t2, 1, datetime.now())
+
+    def fake_sim(self):
+        self.partida.placar_casa = 3
+        self.partida.placar_visitante = 1
+    
+    monkeypatch.setattr(SimuladorPartida, 'simular', fake_sim)
+    partida.simular()
+
+    assert t1.pontos == 3
+    assert t2.pontos == 0
+    assert t1.saldo_gols == 2
+    assert t2.saldo_gols == -2
+


### PR DESCRIPTION
## Summary
- update `Partida` to keep track of result application and update team points and goal difference
- call `aplicar_resultado` at the end of `Partida.simular`
- delegate result update in `Liga` to `Partida.aplicar_resultado`
- add unit test for automatic result application

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee14789c08325a290242be300d86c