### PR TITLE
Refatorar simulador de partida

### DIFF
--- a/core/entities/simulador_partida.py
+++ b/core/entities/simulador_partida.py
@@ -3,6 +3,91 @@
 import random
 from .partida import Partida
 from ..enums.fase_partida import FasePartida
+from .time import Time
+
+
+def calcula_numero_de_fases() -> int:
+    """Retorna o limite de fases de uma partida simples."""
+    return 20
+
+
+def rolar_meio_campo(simulador: "SimuladorPartida") -> None:
+    """Define posse de bola no meio campo."""
+    simulador.subphase = 1
+    simulador.phase += 1
+    simulador.partida.fases.append(FasePartida.MEIO_CAMPO)
+
+    roll_casa = random.random() * simulador.modifier_casa
+    roll_visitante = random.random() * simulador.modifier_visitante
+    simulador.possession = (
+        simulador.partida.time_casa
+        if roll_casa >= roll_visitante
+        else simulador.partida.time_visitante
+    )
+
+
+def rolar_ataque(simulador: "SimuladorPartida") -> bool:
+    """Resolve a tentativa de ataque."""
+    simulador.subphase = 2
+    simulador.phase += 1
+    simulador.partida.fases.append(FasePartida.ATAQUE)
+
+    ataque = random.random() * (
+        simulador.modifier_casa
+        if simulador.possession == simulador.partida.time_casa
+        else simulador.modifier_visitante
+    )
+    defesa = random.random()
+    if ataque < defesa:
+        simulador.possession = (
+            simulador.partida.time_visitante
+            if simulador.possession == simulador.partida.time_casa
+            else simulador.partida.time_casa
+        )
+        return False
+    return True
+
+
+def chutar_gol(simulador: "SimuladorPartida") -> float:
+    """Realiza o chute ao gol e retorna sua força."""
+    simulador.subphase = 3
+    simulador.phase += 1
+    simulador.partida.fases.append(FasePartida.GOL)
+    return random.random() * (
+        simulador.modifier_casa
+        if simulador.possession == simulador.partida.time_casa
+        else simulador.modifier_visitante
+    )
+
+
+def defesa_goleiro(simulador: "SimuladorPartida", chute: float) -> None:
+    """Avalia a defesa do goleiro e registra gol se necessário."""
+    simulador.subphase = 4
+    simulador.phase += 1
+    simulador.partida.fases.append(FasePartida.DEFESA)
+
+    defesa = random.random()
+    if chute > defesa:
+        if simulador.possession == simulador.partida.time_casa:
+            simulador.partida.placar_casa += 1
+            _registrar_gol(simulador.partida.time_casa)
+        else:
+            simulador.partida.placar_visitante += 1
+            _registrar_gol(simulador.partida.time_visitante)
+    else:
+        simulador.possession = (
+            simulador.partida.time_visitante
+            if simulador.possession == simulador.partida.time_casa
+            else simulador.partida.time_casa
+        )
+
+
+def _registrar_gol(time: Time) -> None:
+    """Soma um gol para um jogador aleatório do ``time``."""
+    if not time.jogadores:
+        return
+    jogador = random.choice(time.jogadores)
+    jogador.gols += 1
 
 class SimuladorPartida:
     """Executa uma simulação simplificada de partida."""
@@ -16,59 +101,18 @@ class SimuladorPartida:
         self.modifier_visitante = 1.0
 
     def simular(self) -> None:
-        """Executa fases limitadas em meio-campo, ataque e gol."""
-        while self.phase < 20:
-            self._meio_campo()
-            if self.phase >= 20:
+        """Executa até 20 fases alternando meio-campo, ataque e finalizações."""
+        limite = calcula_numero_de_fases()
+        while self.phase < limite:
+            rolar_meio_campo(self)
+            if self.phase >= limite:
                 break
-            self._ataque()
-            if self.phase >= 20:
+            if not rolar_ataque(self):
+                continue
+            if self.phase >= limite:
                 break
-            self._gol()
+            chute = chutar_gol(self)
+            if self.phase >= limite:
+                break
+            defesa_goleiro(self, chute)
         self.partida.concluida = True
-
-    def _meio_campo(self) -> None:
-        self.subphase = 1
-        self.phase += 1
-        self.partida.fases.append(FasePartida.MEIO_CAMPO)
-        roll_casa = random.random() * self.modifier_casa
-        roll_visitante = random.random() * self.modifier_visitante
-        if roll_casa >= roll_visitante:
-            self.possession = self.partida.time_casa
-        else:
-            self.possession = self.partida.time_visitante
-
-    def _ataque(self) -> None:
-        self.subphase = 2
-        self.phase += 1
-        self.partida.fases.append(FasePartida.ATAQUE)
-        ataque = random.random() * (
-            self.modifier_casa if self.possession == self.partida.time_casa else self.modifier_visitante
-        )
-        defesa = random.random()
-        if ataque < defesa:
-            self.possession = (
-                self.partida.time_visitante
-                if self.possession == self.partida.time_casa
-                else self.partida.time_casa
-            )
-
-    def _gol(self) -> None:
-        self.subphase = 3
-        self.phase += 1
-        self.partida.fases.append(FasePartida.GOL)
-        chute = random.random() * (
-            self.modifier_casa if self.possession == self.partida.time_casa else self.modifier_visitante
-        )
-        defesa = random.random()
-        if chute > defesa:
-            if self.possession == self.partida.time_casa:
-                self.partida.placar_casa += 1
-            else:
-                self.partida.placar_visitante += 1
-        else:
-            self.possession = (
-                self.partida.time_visitante
-                if self.possession == self.partida.time_casa
-                else self.partida.time_casa
-            )


### PR DESCRIPTION
## Summary
- criar funções de apoio para sortear meio-campo, ataque, chute e defesa de goleiro
- atualizar `SimuladorPartida` para usar a nova rotina em até 20 fases
- registrar gols para jogadores do time que marcou

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee148704c8325baed44dde874d6a4