### PR TITLE
Implement goal event tracking

### DIFF
--- a/core/entities/liga.py
+++ b/core/entities/liga.py
@@ -2,9 +2,15 @@
 
 from .competicao import Competicao
 from .partida import Partida
+from .jogador import Jogador
 
 class Liga(Competicao):
     """Liga em formato de pontos corridos."""
+
+    def __init__(self, nome: str, temporada: int, dependente_de: Competicao | None = None) -> None:
+        super().__init__(nome, temporada, dependente_de)
+        self.artilharia: dict[Jogador, int] = {}
+        self.assistencias: dict[Jogador, int] = {}
 
     def gerar_calendario(self) -> None:
         for time in self.times:

--- a/core/entities/simulador_partida.py
+++ b/core/entities/simulador_partida.py
@@ -3,6 +3,7 @@
 import random
 from .partida import Partida
 from ..enums.fase_partida import FasePartida
+from ..systems.sistema_eventos import registrar_gol
 
 class SimuladorPartida:
     """Executa uma simulação simplificada de partida."""
@@ -64,8 +65,18 @@ class SimuladorPartida:
         if chute > defesa:
             if self.possession == self.partida.time_casa:
                 self.partida.placar_casa += 1
+                time = self.partida.time_casa
             else:
                 self.partida.placar_visitante += 1
+                time = self.partida.time_visitante
+            if time.jogadores:
+                marcador = random.choice(time.jogadores)
+                assist = None
+                if len(time.jogadores) > 1:
+                    candidatos = [j for j in time.jogadores if j is not marcador]
+                    if candidatos:
+                        assist = random.choice(candidatos)
+                registrar_gol(marcador, assist)
         else:
             self.possession = (
                 self.partida.time_visitante

--- a/core/systems/sistema_eventos.py
+++ b/core/systems/sistema_eventos.py
@@ -17,3 +17,17 @@ def verificar_demissao_tecnicos(times: list[Time]) -> None:
     for t in times:
         if t.tecnico and t.tecnico.derrotas_consecutivas >= 5:
             t.tecnico.demitir()
+
+
+def registrar_gol(jogador: Jogador, assist: Jogador | None = None) -> None:
+    """Atualiza estatísticas individuais e tabelas da liga."""
+    jogador.gols += 1
+    if assist:
+        assist.assistencias += 1
+
+    time = jogador.time
+    liga = time.liga if time else None
+    if liga:
+        liga.artilharia[jogador] = jogador.gols
+        if assist:
+            liga.assistencias[assist] = assist.assistencias

--- a/tests/test_eventos.py
+++ b/tests/test_eventos.py
@@ -1,0 +1,25 @@
+from core.entities.liga import Liga
+from core.entities.time import Time
+from core.entities.jogador import Jogador
+from core.enums.posicao import Posicao
+from core.systems.sistema_eventos import registrar_gol
+
+
+def test_registrar_gol_atualiza_estatisticas_e_lideres():
+    liga = Liga('L', 2023)
+    t = Time('A', 'A', 1900, 'X', 'Y')
+    liga.times = [t]
+    t.liga = liga
+
+    j1 = Jogador('J1', 20, 'BR', Posicao.ATACANTE)
+    j2 = Jogador('J2', 20, 'BR', Posicao.MEIA)
+    j1.time = t
+    j2.time = t
+    t.jogadores = [j1, j2]
+
+    registrar_gol(j1, j2)
+
+    assert j1.gols == 1
+    assert j2.assistencias == 1
+    assert liga.artilharia[j1] == 1
+    assert liga.assistencias[j2] == 1


### PR DESCRIPTION
## Summary
- extend `sistema_eventos` with `registrar_gol` to update player stats and league leaderboards
- track `artilharia` and `assistencias` inside `Liga`
- record goals in `SimuladorPartida`
- test goal registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee1489498832580b5f078caefe3f4