### PR TITLE
Add basic match narration system

### DIFF
--- a/core/entities/simulador_partida.py
+++ b/core/entities/simulador_partida.py
@@ -3,6 +3,7 @@
 import random
 from .partida import Partida
 from ..enums.fase_partida import FasePartida
+from ..systems.narrador import narrar
 
 class SimuladorPartida:
     """Executa uma simulação simplificada de partida."""
@@ -17,6 +18,10 @@ class SimuladorPartida:
 
     def simular(self) -> None:
         """Executa fases limitadas em meio-campo, ataque e gol."""
+        narrar(
+            f"Inicio da partida: {self.partida.time_casa.nome} x {self.partida.time_visitante.nome}",
+            self.partida,
+        )
         while self.phase < 20:
             self._meio_campo()
             if self.phase >= 20:
@@ -31,17 +36,20 @@ class SimuladorPartida:
         self.subphase = 1
         self.phase += 1
         self.partida.fases.append(FasePartida.MEIO_CAMPO)
+        narrar("Disputa no meio-campo", self.partida)
         roll_casa = random.random() * self.modifier_casa
         roll_visitante = random.random() * self.modifier_visitante
         if roll_casa >= roll_visitante:
             self.possession = self.partida.time_casa
         else:
             self.possession = self.partida.time_visitante
+        self._verificar_cartoes()
 
     def _ataque(self) -> None:
         self.subphase = 2
         self.phase += 1
         self.partida.fases.append(FasePartida.ATAQUE)
+        narrar(f"{self.possession.nome} parte para o ataque", self.partida)
         ataque = random.random() * (
             self.modifier_casa if self.possession == self.partida.time_casa else self.modifier_visitante
         )
@@ -52,11 +60,13 @@ class SimuladorPartida:
                 if self.possession == self.partida.time_casa
                 else self.partida.time_casa
             )
-
+            narrar("A defesa leva a melhor", self.partida)
+        self._verificar_cartoes()
     def _gol(self) -> None:
         self.subphase = 3
         self.phase += 1
         self.partida.fases.append(FasePartida.GOL)
+        narrar(f"{self.possession.nome} finaliza ao gol", self.partida)
         chute = random.random() * (
             self.modifier_casa if self.possession == self.partida.time_casa else self.modifier_visitante
         )
@@ -64,11 +74,23 @@ class SimuladorPartida:
         if chute > defesa:
             if self.possession == self.partida.time_casa:
                 self.partida.placar_casa += 1
+                narrar(f"GOL do {self.partida.time_casa.nome}!", self.partida)
             else:
                 self.partida.placar_visitante += 1
+                narrar(f"GOL do {self.partida.time_visitante.nome}!", self.partida)
         else:
             self.possession = (
                 self.partida.time_visitante
                 if self.possession == self.partida.time_casa
                 else self.partida.time_casa
             )
+            narrar("A bola n\u00e3o entrou", self.partida)
+        self._verificar_cartoes()
+
+    def _verificar_cartoes(self) -> None:
+        """Sorteia aplicação de cartões aleatoriamente."""
+        chance = random.random()
+        if chance < 0.02:
+            narrar(f"Cartão amarelo para {self.possession.nome}", self.partida)
+        elif chance < 0.025:
+            narrar(f"Cartão vermelho para {self.possession.nome}", self.partida)

--- a/core/systems/narrador.py
+++ b/core/systems/narrador.py
@@ -1,0 +1,10 @@
+"""Registro simples de narra\u00e7\u00e3o de partidas."""
+
+from __future__ import annotations
+
+from ..entities.partida import Partida
+
+
+def narrar(texto: str, partida: Partida) -> None:
+    """Adiciona ``texto`` ao hist\u00f3rico de eventos da ``partida``."""
+    partida.eventos.append(texto)

--- a/gui/frames/partida_frame.py
+++ b/gui/frames/partida_frame.py
@@ -3,9 +3,26 @@
 import tkinter as tk
 from ..widgets.partida_widget import PartidaWidget
 
+
+class _Feed(tk.Text):
+    """Text widget para exibir eventos."""
+
+    def __init__(self, master: tk.Misc, partida) -> None:
+        super().__init__(master, height=10, state="disabled")
+        self.partida = partida
+        self._atualizar()
+
+    def _atualizar(self) -> None:
+        self.config(state="normal")
+        self.delete("1.0", tk.END)
+        self.insert("end", "\n".join(self.partida.eventos))
+        self.config(state="disabled")
+        self.after(500, self._atualizar)
+
 class PartidaFrame(tk.Frame):
     """Exibe uma partida."""
 
     def __init__(self, master: tk.Misc, partida) -> None:
         super().__init__(master)
         PartidaWidget(self, partida).pack()
+        _Feed(self, partida).pack(fill="both", expand=True)


### PR DESCRIPTION
## Summary
- implement `narrar()` to log match events
- integrate narration into `SimuladorPartida`
- display narration feed in `PartidaFrame`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ee148edc88325b2282b3e595d182d