### PR TITLE
Implement lineup and new GUI frames

### DIFF
--- a/gui/frames/__init__.py
+++ b/gui/frames/__init__.py
@@ -1,0 +1,19 @@
+"""Subpacote contendo frames da interface gráfica."""
+
+from .main_menu_frame import MainMenuFrame
+from .manager_frame import ManagerFrame
+from .classificacao_frame import ClassificacaoFrame
+from .partida_frame import PartidaFrame
+from .historico_frame import HistoricoFrame
+from .financas_frame import FinancasFrame
+from .mercado_transferencias_frame import MercadoTransferenciasFrame
+
+__all__ = [
+    "MainMenuFrame",
+    "ManagerFrame",
+    "ClassificacaoFrame",
+    "PartidaFrame",
+    "HistoricoFrame",
+    "FinancasFrame",
+    "MercadoTransferenciasFrame",
+]

--- a/gui/frames/financas_frame.py
+++ b/gui/frames/financas_frame.py
@@ -1,0 +1,13 @@
+"""Frame para exibir informações financeiras do time."""
+
+import tkinter as tk
+
+
+class FinancasFrame(tk.Frame):
+    """Mostra orçamento e despesas salariais."""
+
+    def __init__(self, master: tk.Misc, time) -> None:
+        super().__init__(master)
+        self.time = time
+        tk.Label(self, text="Orçamento: R$ {:,.0f}".format(time.orcamento)).pack(anchor="w")
+        tk.Label(self, text="Despesas salariais semanais: R$ {:,.0f}".format(time.despesas_salariais)).pack(anchor="w")

--- a/gui/frames/mercado_transferencias_frame.py
+++ b/gui/frames/mercado_transferencias_frame.py
@@ -1,0 +1,13 @@
+"""Frame para mostrar jogadores disponíveis no mercado de transferências."""
+
+import tkinter as tk
+from ..widgets.jogador_widget import JogadorWidget
+
+
+class MercadoTransferenciasFrame(tk.Frame):
+    """Lista jogadores de outros times."""
+
+    def __init__(self, master: tk.Misc, jogadores) -> None:
+        super().__init__(master)
+        for j in jogadores:
+            JogadorWidget(self, j).pack(anchor="w")

--- a/simulation/manager/modo_manager.py
+++ b/simulation/manager/modo_manager.py
@@ -2,17 +2,55 @@
 
 from ...core.entities.time import Time
 from ...core.entities.partida import Partida
+from ...core.entities.jogador import Jogador
+from ...core.enums.posicao import Posicao
+from ...persistence.save_system import SaveSystem
 
 class ModoPlayer:
     """Permite controle de um time pelo jogador."""
 
     def __init__(self, time: Time) -> None:
         self.time = time
+        self.escalacao: list[Jogador] | None = None
 
     def escolher_escalacao(self) -> None:
-        """Método placeholder para escolha de escalação."""
-        pass
+        """Seleciona automaticamente uma escalação 4-3-3."""
+        jogadores = list(self.time.jogadores)
+        if not jogadores:
+            self.escalacao = []
+            return
+
+        def sort_key(j: Jogador) -> int:
+            return getattr(j, "qualidade_geral", 0)
+
+        goleiros = sorted([j for j in jogadores if j.posicao == Posicao.GOLEIRO], key=sort_key, reverse=True)
+        zagueiros = sorted([j for j in jogadores if j.posicao in (Posicao.ZAGUEIRO, Posicao.LATERAL)], key=sort_key, reverse=True)
+        meias = sorted([j for j in jogadores if j.posicao in (Posicao.VOLANTE, Posicao.MEIA)], key=sort_key, reverse=True)
+        atacantes = sorted([j for j in jogadores if j.posicao == Posicao.ATACANTE], key=sort_key, reverse=True)
+
+        escala = []
+        if goleiros:
+            escala.append(goleiros.pop(0))
+
+        escala.extend(zagueiros[:4])
+        escala.extend(meias[:3])
+        escala.extend(atacantes[:3])
+
+        if len(escala) < 11:
+            restantes = [j for j in jogadores if j not in escala]
+            escala.extend(sorted(restantes, key=sort_key, reverse=True)[: 11 - len(escala)])
+
+        self.escalacao = escala[:11]
 
     def avancar_partida(self, partida: Partida) -> None:
         """Avança uma partida controlada."""
         partida.simular()
+
+    def salvar(self, path: str) -> None:
+        """Salva o estado atual do manager."""
+        SaveSystem.salvar(path, self)
+
+    @staticmethod
+    def carregar(path: str) -> "ModoPlayer":
+        """Carrega um manager salvo."""
+        return SaveSystem.carregar(path)


### PR DESCRIPTION
## Summary
- build automatic 4-3-3 lineup and add save/load methods for `ModoPlayer`
- add finance and transfer market frames to GUI
- expose new frames in package `gui.frames`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee1495ed8832599307173791de393