### PR TITLE
Add schedule validation

### DIFF
--- a/core/entities/calendario.py
+++ b/core/entities/calendario.py
@@ -2,6 +2,7 @@
 
 from datetime import date, timedelta
 from .partida import Partida
+from .time import Time
 
 class Calendario:
     """Armazena partidas e calcula datas disponíveis."""
@@ -24,3 +25,38 @@ class Calendario:
             while any(abs(((p.data.date() if hasattr(p.data, 'date') else p.data) - data).days) < 3 for p in self.partidas):
                 data += timedelta(days=1)
         return data
+
+    def verificar_temporada(self, temporada: int) -> bool:
+        """Verifica se todas as partidas estão dentro da temporada indicada."""
+        inicio = date(temporada, 1, 1)
+        fim = date(temporada, 12, 31)
+        for partida in self.partidas:
+            data = partida.data.date() if hasattr(partida.data, "date") else partida.data
+            if not (inicio <= data <= fim):
+                return False
+        return True
+
+    def verificar_espacamento_times(self, times: list[Time], dias: int = 3) -> bool:
+        """Garante espaçamento mínimo de ``dias`` para cada time."""
+        for time in times:
+            jogos = sorted(
+                [p.data for p in self.partidas if p.time_casa is time or p.time_visitante is time]
+            )
+            for d1, d2 in zip(jogos, jogos[1:]):
+                if (d2 - d1).days < dias:
+                    return False
+        return True
+
+    def verificar_distribuicao_mensal(self) -> bool:
+        """Verifica se há distribuição razoável de partidas entre os meses."""
+        total = len(self.partidas)
+        if total < 10:
+            return True
+        contagem: dict[int, int] = {}
+        for partida in self.partidas:
+            mes = partida.data.month
+            contagem[mes] = contagem.get(mes, 0) + 1
+        if len(contagem) <= 1:
+            return False
+        media = total / len(contagem)
+        return all(abs(c - media) <= 5 for c in contagem.values())

--- a/core/entities/copa.py
+++ b/core/entities/copa.py
@@ -29,3 +29,6 @@ class Copa(Competicao):
                 nova_rodada.append(partida)
             times = [p.time_casa for p in nova_rodada]
             rodada += 1
+        self.calendario.verificar_temporada(self.temporada)
+        self.calendario.verificar_espacamento_times(self.times)
+        self.calendario.verificar_distribuicao_mensal()

--- a/core/entities/liga.py
+++ b/core/entities/liga.py
@@ -17,6 +17,9 @@ class Liga(Competicao):
             time.liga = self
         super().gerar_calendario()
         self.classificacao = self.times[:]
+        self.calendario.verificar_temporada(self.temporada)
+        self.calendario.verificar_espacamento_times(self.times)
+        self.calendario.verificar_distribuicao_mensal()
 
     def _aplicar_resultado(self, partida: Partida) -> None:
         """Atualiza pontuação e saldo de gols usando a partida."""

--- a/core/entities/simulador_partida.py
+++ b/core/entities/simulador_partida.py
@@ -103,28 +103,23 @@ class SimuladorPartida:
         self.modifier_visitante = 1.0
 
     def simular(self) -> None:
-        """Executa fases limitadas em meio-campo, ataque e gol."""
+        """Executa até 20 fases alternando meio-campo, ataque e finalizações."""
         narrar(
             f"Inicio da partida: {self.partida.time_casa.nome} x {self.partida.time_visitante.nome}",
             self.partida,
         )
-        while self.phase < 20:
-            self._meio_campo()
-            if self.phase >= 20:
-        """Executa até 20 fases alternando meio-campo, ataque e finalizações."""
         limite = calcula_numero_de_fases()
         while self.phase < limite:
             rolar_meio_campo(self)
             if self.phase >= limite:
                 break
-            if not rolar_ataque(self):
-                continue
-            if self.phase >= limite:
-                break
-            chute = chutar_gol(self)
-            if self.phase >= limite:
-                break
-            defesa_goleiro(self, chute)
+            if rolar_ataque(self):
+                if self.phase >= limite:
+                    break
+                chute = chutar_gol(self)
+                if self.phase >= limite:
+                    break
+                defesa_goleiro(self, chute)
         self.partida.concluida = True
 
     def _meio_campo(self) -> None:
@@ -169,14 +164,9 @@ class SimuladorPartida:
         if chute > defesa:
             if self.possession == self.partida.time_casa:
                 self.partida.placar_casa += 1
-                narrar(f"GOL do {self.partida.time_casa.nome}!", self.partida)
             else:
                 self.partida.placar_visitante += 1
-                narrar(f"GOL do {self.partida.time_visitante.nome}!", self.partida)
-                time = self.partida.time_casa
-            else:
-                self.partida.placar_visitante += 1
-                time = self.partida.time_visitante
+            time = self.possession
             if time.jogadores:
                 marcador = random.choice(time.jogadores)
                 assist = None
@@ -185,6 +175,7 @@ class SimuladorPartida:
                     if candidatos:
                         assist = random.choice(candidatos)
                 registrar_gol(marcador, assist)
+            narrar(f"GOL do {time.nome}!", self.partida)
         else:
             self.possession = (
                 self.partida.time_visitante
@@ -201,3 +192,4 @@ class SimuladorPartida:
             narrar(f"Cartão amarelo para {self.possession.nome}", self.partida)
         elif chance < 0.025:
             narrar(f"Cartão vermelho para {self.possession.nome}", self.partida)
+

--- a/tests/test_calendario.py
+++ b/tests/test_calendario.py
@@ -12,3 +12,45 @@ def test_proxima_data_disponivel():
     cal.adicionar_partida(p1)
     next_date = cal.proxima_data_disponivel(date(2023, 1, 2))
     assert (next_date - p1.data).days >= 3
+
+
+def test_verificar_temporada():
+    cal = Calendario()
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    cal.partidas = [
+        Partida(t1, t2, 1, date(2023, 1, 1)),
+        Partida(t1, t2, 2, date(2024, 1, 1)),
+    ]
+    assert not cal.verificar_temporada(2023)
+
+
+def test_verificar_espacamento_times():
+    cal = Calendario()
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    t3 = Time('C', 'C', 1900, 'X', 'Y')
+    cal.partidas = [
+        Partida(t1, t2, 1, date(2023, 1, 1)),
+        Partida(t1, t3, 2, date(2023, 1, 2)),
+    ]
+    assert not cal.verificar_espacamento_times([t1, t2, t3])
+    cal.partidas[1].data = date(2023, 1, 4)
+    assert cal.verificar_espacamento_times([t1, t2, t3])
+
+
+def test_verificar_distribuicao_mensal():
+    cal = Calendario()
+    t1 = Time('A', 'A', 1900, 'X', 'Y')
+    t2 = Time('B', 'B', 1900, 'X', 'Y')
+    from datetime import timedelta
+
+    for i in range(12):
+        cal.partidas.append(Partida(t1, t2, i + 1, date(2023, 1, 1) + timedelta(days=i)))
+    assert not cal.verificar_distribuicao_mensal()
+
+    cal.partidas.clear()
+    for m in range(1, 7):
+        cal.partidas.append(Partida(t1, t2, m * 2 - 1, date(2023, m, 1)))
+        cal.partidas.append(Partida(t1, t2, m * 2, date(2023, m, 15)))
+    assert cal.verificar_distribuicao_mensal()


### PR DESCRIPTION
## Summary
- expand calendar with verification methods
- validate schedules after league and cup calendar generation
- fix `SimuladorPartida` indentation
- test calendar validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eeb2ec4c483258d434ec373c8704b